### PR TITLE
Add GSSAPI user authentication method

### DIFF
--- a/doc/api-auth.texi
+++ b/doc/api-auth.texi
@@ -125,6 +125,26 @@ In nonblocking mode, you've got to call this again later.
 
 @end deffn
 
+@deffn {Scheme Procedure} userauth-gssapi! session
+Try to authenticate through the @code{gssapi-with-mic} method.
+
+Return one of the following symbols: 
+
+@table @samp
+@item success
+Authentication success.
+@item partial
+You've been partially authenticated, you still have to use another method.
+@item again
+In nonblocking mode, you've got to call this again later.
+@item denied
+Authentication failed: use another method.
+@item error
+A serious error happened.
+@end table
+
+@end deffn
+
 @deffn {Scheme Procedure} userauth-none! session
 Try to authenticate through the @code{none} method.
 

--- a/libguile-ssh/auth.c
+++ b/libguile-ssh/auth.c
@@ -206,6 +206,27 @@ Throw `wrong-type-arg' if a disconnected SESSION is passed as an argument.\
 }
 #undef FUNC_NAME
 
+SCM_DEFINE (guile_ssh_userauth_gssapi_x,
+            "userauth-gssapi!", 1, 0, 0,
+            (SCM session),
+            "\
+Try to authenticate through the \"gssapi-with-mic\" method.\
+Throw `wrong-type-arg' if a disconnected SESSION is passed as an argument.\
+")
+#define FUNC_NAME s_guile_ssh_userauth_gssapi_x
+{
+  struct session_data *sd = _scm_to_session_data (session);
+
+  int res;
+
+  GSSH_VALIDATE_CONNECTED_SESSION (sd, session, SCM_ARG1);
+
+  res = ssh_userauth_gssapi (sd->ssh_session);
+
+  return ssh_auth_result_to_symbol (res);
+}
+#undef FUNC_NAME
+
 
 /* Try to authenticate through the "none" method.
 

--- a/modules/ssh/auth.scm
+++ b/modules/ssh/auth.scm
@@ -29,6 +29,7 @@
 ;;   userauth-public-key/try
 ;;   userauth-agent!
 ;;   userauth-password!
+;;   userauth-gssapi!
 ;;   userauth-none!
 ;;   userauth-get-list
 
@@ -46,6 +47,7 @@
             userauth-public-key/try
             userauth-agent!
             userauth-password!
+            userauth-gssapi!
             userauth-none!
             userauth-get-list
             openssh-agent-start

--- a/tests/client-server.scm
+++ b/tests/client-server.scm
@@ -429,6 +429,19 @@
   (userauth-public-key/auto! (make-session-for-test)))
 
 
+;;; 'userauth-gssapi!'
+
+;; The procedure called with a wrong object as a parameter which leads to an
+;; exception.
+(test-error-with-log "userauth-gssapi!, wrong parameter" 'wrong-type-arg
+  (userauth-gssapi! "Not a session."))
+
+;; Client tries to authenticate using a non-connected session which leads to
+;; an exception.
+(test-error-with-log "userauth-gssapi!, not connected" 'wrong-type-arg
+  (userauth-gssapi! (make-session-for-test)))
+
+
 ;;;
 
 


### PR DESCRIPTION
Bind to libssh’s ssh_userauth_gssapi(). I don’t know how to add a proper test case right now, but the code is straight-forward and a modified sssh.scm authenticates correctly against a kerberized SSH server.

My intention is to add GSSAPI authentication to guix’ remote daemon mode via SSH. See https://debbugs.gnu.org/cgi/bugreport.cgi?bug=38541