### PR TITLE
build: Fix cross-compilation.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -109,6 +109,8 @@ AC_CONFIG_FILES([m4/Makefile doc/Makefile tests/Makefile am/Makefile])
 AC_CONFIG_FILES([modules/Makefile modules/ssh/Makefile modules/ssh/dist/Makefile])
 AC_CONFIG_FILES([modules/srfi/Makefile])
 
+AM_CONDITIONAL([CROSS_COMPILING], [test "x$cross_compiling" = "xyes"])
+
 # Generate a Makefile, based on the results.
 AC_OUTPUT
 

--- a/libguile-ssh/Makefile.am
+++ b/libguile-ssh/Makefile.am
@@ -60,7 +60,7 @@ snarfcppopts = $(DEFS) $(INCLUDES) $(CPPFLAGS) $(CFLAGS) $(GUILE_CFLAGS) \
 
 SUFFIXES = .x
 .c.x:
-	$(AM_V_SNARF)$(GUILE_SNARF) -o $@ $< $(snarfcppopts)
+	$(AM_V_SNARF) CPP="$(CPP)" $(GUILE_SNARF) -o $@ $< $(snarfcppopts)
 
 CLEANFILES = *.x
 

--- a/modules/ssh/Makefile.am
+++ b/modules/ssh/Makefile.am
@@ -56,9 +56,16 @@ guilec_opts = 					\
 	--target=$(host)			\
 	$(guilec_warnings)
 
+if CROSS_COMPILING
+CROSS_COMPILING_VARIABLE = GUILE_SSH_CROSS_COMPILING=yes
+else
+CROSS_COMPILING_VARIABLE =
+endif
+
 # TODO: Move environment setup to a separate file.
 guilec_env  = 									\
 	GUILE_AUTO_COMPILE=0 							\
+	$(CROSS_COMPILING_VARIABLE)                                      	\
 	LD_LIBRARY_PATH="$(abs_top_builddir)/libguile-ssh/.libs/:${LD_LIBRARY_PATH}"	\
 	GUILE_LOAD_PATH="$(abs_top_srcdir)/modules"					\
 	GUILE_LOAD_COMPILED_PATH="$(builddir)/ssh:$$GUILE_LOAD_COMPILED_PATH"

--- a/modules/ssh/auth.scm
+++ b/modules/ssh/auth.scm
@@ -126,6 +126,7 @@
 
 ;;;
 
-(load-extension "libguile-ssh" "init_auth_func")
+(unless (getenv "GUILE_SSH_CROSS_COMPILING")
+  (load-extension "libguile-ssh" "init_auth_func"))
 
 ;;; auth.scm ends here.

--- a/modules/ssh/channel.scm
+++ b/modules/ssh/channel.scm
@@ -125,6 +125,8 @@ an error.  Return value is undefined."
 ;;;
 
 
-(load-extension "libguile-ssh" "init_channel")
+
+(unless (getenv "GUILE_SSH_CROSS_COMPILING")
+  (load-extension "libguile-ssh" "init_channel"))
 
 ;;; channel.scm ends here.

--- a/modules/ssh/dist/Makefile.am
+++ b/modules/ssh/dist/Makefile.am
@@ -51,9 +51,16 @@ guilec_opts = 					\
 	--target=$(host)			\
 	$(guilec_warnings)
 
+if CROSS_COMPILING
+CROSS_COMPILING_VARIABLE = GUILE_SSH_CROSS_COMPILING=yes
+else
+CROSS_COMPILING_VARIABLE =
+endif
+
 # TODO: Move environment setup to a separate file.
 guilec_env  = 									\
 	GUILE_AUTO_COMPILE=0 							\
+	$(CROSS_COMPILING_VARIABLE)                                      	\
 	LD_LIBRARY_PATH="$(abs_top_builddir)/libguile-ssh/.libs/:${LD_LIBRARY_PATH}"	\
 	GUILE_LOAD_PATH="$(abs_top_srcdir)/modules"				\
 	GUILE_LOAD_COMPILED_PATH="$(builddir)/ssh:$$GUILE_LOAD_COMPILED_PATH"

--- a/modules/ssh/key.scm
+++ b/modules/ssh/key.scm
@@ -66,6 +66,7 @@
                     (bytevector->u8-list bv))
                ":"))
 
-(load-extension "libguile-ssh" "init_key")
+(unless (getenv "GUILE_SSH_CROSS_COMPILING")
+  (load-extension "libguile-ssh" "init_key"))
 
 ;;; key.scm ends here.

--- a/modules/ssh/log.scm
+++ b/modules/ssh/log.scm
@@ -64,9 +64,10 @@ Return value is undefined."
   (let ((message (apply format #f format-string args)))
     (%write-log priority procedure-name message)))
 
-(load-extension "libguile-ssh" "init_log_func")
+(unless (getenv "GUILE_SSH_CROSS_COMPILING")
+  (load-extension "libguile-ssh" "init_log_func")
 
-;; Set the default log printer.
-(set-logging-callback! %default-log-printer)
+  ;; Set the default log printer.
+  (set-logging-callback! %default-log-printer))
 
 ;;; log.scm ends here

--- a/modules/ssh/message.scm
+++ b/modules/ssh/message.scm
@@ -145,6 +145,8 @@ to use will be selected depending on a type of the message MSG."
        (error "Unknown message type" msg-type)))))
 
 
-(load-extension "libguile-ssh" "init_message")
+
+(unless (getenv "GUILE_SSH_CROSS_COMPILING")
+  (load-extension "libguile-ssh" "init_message"))
 
 ;;; message.scm ends here

--- a/modules/ssh/server.scm
+++ b/modules/ssh/server.scm
@@ -70,6 +70,7 @@ Return a new SSH server."
     (server-set-if-specified! blocking-mode)
     server))
 
-(load-extension "libguile-ssh" "init_server")
+(unless (getenv "GUILE_SSH_CROSS_COMPILING")
+  (load-extension "libguile-ssh" "init_server"))
 
 ;;; server.scm ends here

--- a/modules/ssh/session.scm
+++ b/modules/ssh/session.scm
@@ -120,6 +120,7 @@ set, the default SSH '~/.ssh/config' is used.  Throw 'guile-ssh-error' on an
 error.  Return value is undefined."
   (%gssh-session-parse-config! session file-name))
 
-(load-extension "libguile-ssh" "init_session")
+(unless (getenv "GUILE_SSH_CROSS_COMPILING")
+  (load-extension "libguile-ssh" "init_session"))
 
 ;;; session.scm ends here

--- a/modules/ssh/sftp.scm
+++ b/modules/ssh/sftp.scm
@@ -250,8 +250,9 @@ behavior is implementation dependent."
 
 ;;; Load libraries.
 
-(load-extension "libguile-ssh" "init_sftp_session")
-(load-extension "libguile-ssh" "init_sftp_file")
+(unless (getenv "GUILE_SSH_CROSS_COMPILING")
+  (load-extension "libguile-ssh" "init_sftp_session")
+  (load-extension "libguile-ssh" "init_sftp_file"))
 
 ;;; sftp-session.scm ends here.
 

--- a/modules/ssh/version.scm
+++ b/modules/ssh/version.scm
@@ -50,7 +50,8 @@
             ;; Low-level procedures
             %get-libssh-version))
 
-(load-extension "libguile-ssh" "init_version")
+(unless (getenv "GUILE_SSH_CROSS_COMPILING")
+  (load-extension "libguile-ssh" "init_version"))
 
 (define (get-libssh-version)
   "Get version of the libssh."

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -19,6 +19,8 @@
 
 include $(top_srcdir)/am/guilec
 
+if !CROSS_COMPILING
+
 SCM_TESTS = \
 	log.scm \
 	server.scm \
@@ -124,3 +126,10 @@ CLEANFILES = \
 	sssh-ssshd-libssh.log			\
 	sssh-ssshd-errors.log			\
 	$(GOBJECTS)
+
+else CROSS_COMPILING
+
+TESTS =
+SCM_TESTS =
+
+endif CROSS_COMPILING


### PR DESCRIPTION
* configure.ac: Set CROSS_COMPILING variable when cross compiling.
* libguile-ssh/Makefile.am: Set CPP variable when calling guile-snarf to force
the use of the cross-compiler.
* modules/ssh/Makefile.am: Set GUILE_SSH_CROSS_COMPILING variable when cross
  compiling.
* modules/ssh/dist/Makefile.am: Ditto.
* tests/Makefile.am: Do no build tests when cross compiling.
* modules/ssh/auth.scm: Do not load extension when cross-compiling.
* modules/ssh/channel.scm: Ditto.
* modules/ssh/key.scm: Ditto.
* modules/ssh/log.scm: Ditto.
* modules/ssh/message.scm: Ditto.
* modules/ssh/server.scm: Ditto.
* modules/ssh/session.scm: Ditto.
* modules/ssh/version.scm: Ditto.