### PR TITLE
Spelling fixes

### DIFF
--- a/doc/api-channels.texi
+++ b/doc/api-channels.texi
@@ -209,7 +209,7 @@ Success.
 @item again
 We are in the nonblocking mode and the call to be done again.
 @item error
-An error occured.
+An error occurred.
 @end table
 
 The local port forwarding works as follows:
@@ -265,7 +265,7 @@ Success.
 @item again
 We are in the nonblocking mode and the call to be done again.
 @item error
-An error occured.
+An error occurred.
 @end table
 
 Reverse port forwarding looks as follows:
@@ -306,7 +306,7 @@ Success.
 @item again
 We are in the nonblocking mode and the call to be done again.
 @item error
-An error occured.
+An error occurred.
 @end table
 
 Here's an example Guile program that uses @code{channel-cancel-forward} to

--- a/doc/api-dist.texi
+++ b/doc/api-dist.texi
@@ -101,7 +101,7 @@ connection to a remote REPL fails), @code{dist-map} transfers the job to
 another node from the @var{nodes} list.  When job execution failed on all
 nodes, an error is reported.
 
-In a case when an error that occured during job execution is considered
+In a case when an error that occurred during job execution is considered
 non-recoverable (eg. when evaluation of @var{proc} on a node failed due to an
 unbound variable) then execution of a job stops immediately.
 @end deffn
@@ -172,11 +172,11 @@ Here's the description of the format of node type printed representation:
 
 There are two types of node errors: recoverable and non-recoverable.  The
 first group is represented by @code{node-error} exceptions.  If an exception
-of this kind is occured then there is a chance that a job can be executed on
+of this kind is occurred then there is a chance that a job can be executed on
 another node.  That's because such an exception occures in cases when a node
 is unreachable, for example.  The second group is represented by
 @code{node-repl-error} exceptions.  Such exceptions mean that an error is
-occured during execution of a job on a node's REPL -- eg. due to the malformed
+occurred during execution of a job on a node's REPL -- eg. due to the malformed
 job.  Those errors are non-recoverable because if the job is broken it will
 likely fail on another nodes as well.
 
@@ -186,7 +186,7 @@ In addition to @code{make-node}, @code{node?}, @code{node-session} and
 @deffn {Scheme Procedure} node-eval node quoted-exp
 Evaluate a @var{quoted-exp} on a @var{node} and return four values: an
 evaluation result, a number of the evaluation, a module name and a language
-name.  Throw @code{node-repl-error} if a non-recoverable error occured, or
+name.  Throw @code{node-repl-error} if a non-recoverable error occurred, or
 @code{node-error} if the evaluation potentially could be succesfully evaluated
 on another node.
 

--- a/doc/api-sessions.texi
+++ b/doc/api-sessions.texi
@@ -88,9 +88,9 @@ the following symbols:
 @item ok
 Success.
 @item again
-@var{timeout} occured.
+@var{timeout} occurred.
 @item error
-An error occured.
+An error occurred.
 @end table
 @end deffn
 
@@ -306,7 +306,7 @@ The server is unknown. User should confirm the MD5 is correct.
 The known host file does not exist. The host is thus unknown. File
 will be created if host key is accepted.
 @item error
-An error occured.
+An error occurred.
 @end table
 
 @end deffn

--- a/doc/api-sftp.texi
+++ b/doc/api-sftp.texi
@@ -29,7 +29,7 @@ Get the parent SSH session for a @var{sftp-session}.
 
 @deffn {Scheme Procedure} sftp-get-error sftp-session
 Get the last SFTP error from a @var{sftp-session}.  Return the error name as a
-symbol, or throw @code{guile-ssh-error} on if an error occured in the
+symbol, or throw @code{guile-ssh-error} on if an error occurred in the
 procedure itself.
 
 The procedure returns one of the following values:

--- a/libguile-ssh/channel-type.c
+++ b/libguile-ssh/channel-type.c
@@ -51,7 +51,7 @@ enum {
 #if USING_GUILE_BEFORE_2_2
 
 /* Read data from the channel.  Return EOF if no data is available or
-   throw `guile-ssh-error' if an error occured. */
+   throw `guile-ssh-error' if an error occurred. */
 static int
 ptob_fill_input (SCM channel)
 #define FUNC_NAME "ptob_fill_input"
@@ -202,7 +202,7 @@ ptob_input_waiting (SCM channel)
   int res = ssh_channel_poll (cd->ssh_channel, cd->is_stderr);
 
   if (res == SSH_ERROR)
-    guile_ssh_error1 (FUNC_NAME, "An error occured.", channel);
+    guile_ssh_error1 (FUNC_NAME, "An error occurred.", channel);
 
   return (res != SSH_EOF) ? res : 0;
 }

--- a/libguile-ssh/sftp-file-type.c
+++ b/libguile-ssh/sftp-file-type.c
@@ -50,7 +50,7 @@ enum {
 #if USING_GUILE_BEFORE_2_2
 
 /* Read data from the channel.  Return EOF if no data is available or
-   throw `guile-ssh-error' if an error occured. */
+   throw `guile-ssh-error' if an error occurred. */
 static int
 ptob_fill_input (SCM file)
 #define FUNC_NAME "ptob_fill_input"

--- a/modules/ssh/dist.scm
+++ b/modules/ssh/dist.scm
@@ -106,7 +106,7 @@ list.  Return the results of N expressions as a set of N multiple values."
     (apply values results)))
 
 (define-syntax-rule (dist-map nodes proc lst)
-  "Do list mapping using distributed computation.  The job is splitted to
+  "Do list mapping using distributed computation.  The job is split into
 nearly equal parts and hand out resulting jobs to a NODES list.  Return the
 result of computation."
   (let* ((jobs    (assign-map nodes lst (quote proc)))

--- a/modules/ssh/sftp.scm
+++ b/modules/ssh/sftp.scm
@@ -113,7 +113,7 @@ on an error"
 
 (define (sftp-get-error sftp-session)
   "Get the last SFTP error from a SFTP-SESSION.  Return the error name as a symbol,
-or throw 'guile-ssh-error' on if an error occured in the procedure itself."
+or throw 'guile-ssh-error' on if an error occurred in the procedure itself."
   (%gssh-sftp-get-error sftp-session))
 
 

--- a/tests/common.scm
+++ b/tests/common.scm
@@ -284,7 +284,7 @@ disconnected when the PROC is finished."
             (loop (1+ num))
             (begin
               (format-log/scm 'nolog "get-unused-port"
-                              "port choosen: ~a" num)
+                              "port chosen: ~a" num)
               (set! port-num num)
               (unlock-mutex mtx)
               num))))))


### PR DESCRIPTION
Some trivial spelling fixes:
choosen -> chosen
splitted to -> split into
occured -> occurred