### PR TITLE
use GUILE_SYSTEM_EXTENSIONS_PATH instead of LD_LIBRARY_PATH

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -35,6 +35,7 @@ AM_INIT_AUTOMAKE([color-tests])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])], [AC_SUBST([AM_DEFAULT_VERBOSITY],1)])
 
 AC_PROG_CC
+LT_INIT([disable-static])
 
 if test "x$GCC" = "xyes"; then
   # Use compiler warnings.

--- a/modules/ssh/Makefile.am
+++ b/modules/ssh/Makefile.am
@@ -66,8 +66,8 @@ endif
 guilec_env  = 									\
 	GUILE_AUTO_COMPILE=0 							\
 	$(CROSS_COMPILING_VARIABLE)                                      	\
-	LD_LIBRARY_PATH="$(abs_top_builddir)/libguile-ssh/.libs/:${LD_LIBRARY_PATH}"	\
-	GUILE_LOAD_PATH="$(abs_top_srcdir)/modules"					\
+	GUILE_SYSTEM_EXTENSIONS_PATH="$(abs_top_builddir)/libguile-ssh/.libs/:${GUILE_SYSTEM_EXTENSIONS_PATH}"	\
+	GUILE_LOAD_PATH="$(abs_top_srcdir)/modules"				\
 	GUILE_LOAD_COMPILED_PATH="$(builddir)/ssh:$$GUILE_LOAD_COMPILED_PATH"
 
 .scm.go:

--- a/modules/ssh/dist/Makefile.am
+++ b/modules/ssh/dist/Makefile.am
@@ -61,7 +61,7 @@ endif
 guilec_env  = 									\
 	GUILE_AUTO_COMPILE=0 							\
 	$(CROSS_COMPILING_VARIABLE)                                      	\
-	LD_LIBRARY_PATH="$(abs_top_builddir)/libguile-ssh/.libs/:${LD_LIBRARY_PATH}"	\
+	GUILE_SYSTEM_EXTENSIONS_PATH="$(abs_top_builddir)/libguile-ssh/.libs/:${GUILE_SYSTEM_EXTENSIONS_PATH}"	\
 	GUILE_LOAD_PATH="$(abs_top_srcdir)/modules"				\
 	GUILE_LOAD_COMPILED_PATH="$(builddir)/ssh:$$GUILE_LOAD_COMPILED_PATH"
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -43,6 +43,7 @@ AM_TESTS_ENVIRONMENT = \
 	abs_top_builddir="$(abs_top_builddir)"; export abs_top_builddir; \
 	ORIGTERM=${TERM}; export ORIGTERM; \
 	TERM=xterm; export TERM; \
+	GUILE=$(GUILE); export GUILE; \
 	GUILE_WARN_DEPRECATED=no; export GUILE_WARN_DEPRECATED; \
 	GUILE_AUTO_COMPILE=0; export GUILE_AUTO_COMPILE;
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,9 +1,9 @@
-## Config file for GNU Automake. 
+## Config file for GNU Automake.
 ##
 ## Copyright (C) 2014, 2015, 2016 Artyom V. Poptsov <poptsov.artyom@gmail.com>
 ##
 ## This file is part of Guile-SSH.
-## 
+##
 ## Guile-SSH is free software: you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
 ## published by the Free Software Foundation, either version 3 of the
@@ -87,8 +87,8 @@ guilec_opts = 					\
 # TODO: Move environment setup to a separate file.
 guilec_env  = 									\
 	GUILE_AUTO_COMPILE=0 							\
-	LD_LIBRARY_PATH="$(abs_top_builddir)/libguile-ssh/.libs/:${LD_LIBRARY_PATH}"	\
-	GUILE_LOAD_PATH="$(abs_top_srcdir)/modules"					\
+	GUILE_SYSTEM_EXTENSIONS_PATH="$(abs_top_builddir)/libguile-ssh/.libs/:${GUILE_SYSTEM_EXTENSIONS_PATH}"	\
+	GUILE_LOAD_PATH="$(abs_top_srcdir)/modules"				\
 	GUILE_LOAD_COMPILED_PATH="$(builddir)/ssh:$$GUILE_LOAD_COMPILED_PATH"
 
 .scm.go:

--- a/tests/common.scm
+++ b/tests/common.scm
@@ -72,6 +72,7 @@
 
 (define %topdir (getenv "abs_top_srcdir"))
 (define %topbuilddir (getenv "abs_top_builddir"))
+(define %guile (getenv "GUILE"))
 (define %addr   "127.0.0.1")
 (define *port*  12400)
 
@@ -560,9 +561,9 @@ main procedure."
       (multifork
        ;; server
        (lambda ()
-         (execle "/usr/bin/guile"
+         (execle %guile
                  (environ)
-                 "/usr/bin/guile"
+                 %guile
                  "-L" (format #f "~a/" %topdir)
                  "-L" (format #f "~a/modules/" %topdir)
                  "-e" "main"

--- a/tests/sssh-ssshd.scm
+++ b/tests/sssh-ssshd.scm
@@ -31,7 +31,7 @@
 
 ;;;
 
-(define *test-cmd* "uname --all")
+(define *test-cmd* "uname -a")
 
 (define *srv-address* INADDR_LOOPBACK)
 (define *srv-port*    12600)


### PR DESCRIPTION
This allows building in macOS and it's generic to any platform and specific to Guile extensions. See commit log for more details.

Also, with this, `guile-ssh` is now available through Guile Homebrew Tap (https://github.com/aconchillo/homebrew-guile).