### PR TITLE
libguile-ssh/session-func.c: Add NODELAY option

### DIFF
--- a/libguile-ssh/session-func.c
+++ b/libguile-ssh/session-func.c
@@ -71,6 +71,7 @@ static struct symbol_mapping session_options[] = {
   { "stricthostkeycheck", SSH_OPTIONS_STRICTHOSTKEYCHECK },
   { "compression",        SSH_OPTIONS_COMPRESSION        },
   { "compression-level",  SSH_OPTIONS_COMPRESSION_LEVEL  },
+  { "nodelay",            SSH_OPTIONS_NODELAY            },
   { "callbacks",          GSSH_OPTIONS_CALLBACKS         },
   { NULL,                 -1 }
 };
@@ -366,6 +367,7 @@ set_option (SCM scm_session, struct session_data* sd, int type, SCM value)
     case SSH_OPTIONS_SSH1:
     case SSH_OPTIONS_SSH2:
     case SSH_OPTIONS_STRICTHOSTKEYCHECK:
+    case SSH_OPTIONS_NODELAY:
       return set_bool_opt (session, type, value);
 
     case SSH_OPTIONS_FD:

--- a/modules/ssh/session.scm
+++ b/modules/ssh/session.scm
@@ -74,7 +74,7 @@
                        knownhosts timeout timeout-usec ssh1 ssh2 log-verbosity
                        ciphers-c-s ciphers-s-c compression-c-s compression-s-c
                        proxycommand stricthostkeycheck compression
-                       compression-level callbacks config)
+                       compression-level nodelay callbacks config)
   "Make a new SSH session with specified configuration.\n
 Return a new SSH session."
   (let ((session (%make-session)))
@@ -98,6 +98,7 @@ Return a new SSH session."
     (session-set-if-specified! stricthostkeycheck)
     (session-set-if-specified! compression)
     (session-set-if-specified! compression-level)
+    (session-set-if-specified! nodelay)
     (session-set-if-specified! callbacks)
 
     (when config

--- a/tests/session.scm
+++ b/tests/session.scm
@@ -70,6 +70,7 @@
                                   nolog)
                    (compression   "yes" "no")
                    (compression-level 1 2 3 4 5 6 7 8 9)
+                   (nodelay      #f #t)
                    (callbacks     ((user-data . "hello")
                                    (global-request-callback . ,(const #f))))))
         (res #t))
@@ -95,6 +96,7 @@
                    (log-verbosity     "string" -1 0 1 2 3 4 5)
                    (compression       12345)
                    (compression-level -1 0 10)
+                   (nodelay           12345 "string")
                    (callbacks         "not a list"
                                       ((global-request-callback . #f)))))
         (res #t))


### PR DESCRIPTION
This pull request adds the nodelay option libssh provides. It is intended to be used by guix, which currently opens its own socket and manually sets NODELAY. See https://issues.guix.gnu.org/41702#11

The Guile 2.2 build pipeline fails, because it’s using a really old version of libssh (0.8.0~20170825.94fa1e38-1ubuntu0.6). NODELAY was introduced in 2018 by https://git.libssh.org/projects/libssh.git/commit/?id=be22c0d442a1c5c016e2ebb99075b61614b5b447