### PR TITLE
libguile-ssh should be installed as an extension

### DIFF
--- a/libguile-ssh/Makefile.am
+++ b/libguile-ssh/Makefile.am
@@ -15,7 +15,9 @@
 ## You should have received a copy of the GNU General Public License
 ## along with Guile-SSH.  If not, see <http://www.gnu.org/licenses/>.
 
-lib_LTLIBRARIES = libguile-ssh.la
+guileextensiondir = $(libdir)/guile/$(GUILE_EFFECTIVE_VERSION)/extensions
+
+guileextension_LTLIBRARIES = libguile-ssh.la
 
 libguile_ssh_la_SOURCES = \
 	auth.c \


### PR DESCRIPTION
This came up in a new Apple M1 where Homebrew is installed in /opt/homebrew instead of /usr/local as Apple intel's. `libguile-ssh` should actually be installed as an extension (as other extensions). This way `GUILE_SYSTEM_EXTENSIONS_PATH` can be used.