### PR TITLE
configure.ac: remove extra character

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -126,7 +126,7 @@ if test "x$have_srfi64" != "xyes"; then
 fi
 
 LT_INIT()
-p
+
 if test "x$guilesitedir" = "x"; then
    guilesitedir="$datadir/guile/site/$GUILE_EFFECTIVE_VERSION"
 fi


### PR DESCRIPTION
I believe all Emacs users have had `p` characters :-D.