### PR TITLE
CI for guix

### DIFF
--- a/.github/workflows/guix.yml
+++ b/.github/workflows/guix.yml
@@ -27,7 +27,7 @@ jobs:
         uses: "actions/checkout@v3"
       - name: "Build project guile-ssh"
         run: |
-          guix build --file guix.scm guile-ssh
+          guix build --file=guix.scm guile-ssh
   aarch64-linux-gnu:
     name: "Guix build on latest commit for aarch64 system"
     runs-on: "ubuntu-latest"
@@ -43,7 +43,7 @@ jobs:
         uses: "actions/checkout@v3"
       - name: "Build project guile-ssh"
         run: |
-          guix build --file guix.scm guile-ssh
+          guix build --file=guix.scm guile-ssh
 
 # End of guix.yml
 ...

--- a/.github/workflows/guix.yml
+++ b/.github/workflows/guix.yml
@@ -5,11 +5,11 @@ name: Guix/Guile 3.0
 
 on:
   push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
+  #   branches:
+  #     - master
+  # pull_request:
+  #   branches:
+  #     - master
 
 jobs:
   x86_64-linux-gnu:

--- a/.github/workflows/guix.yml
+++ b/.github/workflows/guix.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: "Install Guix"
         run: |
-         sudo apt-get update && apt-get install guix
+         sudo apt-get update && sudo apt-get install guix
          guix pull
       - name: "Ensure no locale warning"
         run: |
@@ -34,7 +34,7 @@ jobs:
     steps:
       - name: "Install Guix"
         run: |
-         sudo apt-get update && apt-get install guix
+         sudo apt-get update && sudo apt-get install guix
          guix pull
       - name: "Ensure no locale warning"
         run: |

--- a/.github/workflows/guix.yml
+++ b/.github/workflows/guix.yml
@@ -16,6 +16,14 @@ jobs:
     name: "Guix build on latest commit for x86_64 system"
     runs-on: "ubuntu-latest"
     steps:
+      - name: "Guix cache"
+        uses: "actions/cache@v3"
+        with:
+          path: "~/.cache/guix"
+          # use a key that (almost) never matches
+          key: "guix-cache-${{ github.sha }}"
+          restore-keys: |
+            guix-cache-
       - name: "Install Guix"
         run: |
          sudo apt-get update && sudo apt-get install guix
@@ -32,6 +40,14 @@ jobs:
     name: "Guix build on latest commit for aarch64 system"
     runs-on: "ubuntu-latest"
     steps:
+      - name: "Guix cache"
+        uses: "actions/cache@v3"
+        with:
+          path: "~/.cache/guix"
+          # use a key that (almost) never matches
+          key: "guix-cache-${{ github.sha }}"
+          restore-keys: |
+            guix-cache-
       - name: "Install Guix"
         run: |
          sudo apt-get update && sudo apt-get install guix

--- a/.github/workflows/guix.yml
+++ b/.github/workflows/guix.yml
@@ -17,7 +17,9 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Install Guix"
-        uses: "PromyLOPh/guix-install-action@v1"
+        run: |
+         sudo apt-get update && apt-get install guix
+         guix pull
       - name: "Ensure no locale warning"
         run: |
           test -z "$(guix --version 2>&1 >/dev/null)"
@@ -27,11 +29,13 @@ jobs:
         run: |
           guix build --file guix.scm guile-ssh
   aarch64-linux-gnu:
-    name: "Guix build on latest commit for x86_64 system"
+    name: "Guix build on latest commit for aarch64 system"
     runs-on: "ubuntu-latest"
     steps:
       - name: "Install Guix"
-        uses: "PromyLOPh/guix-install-action@v1"
+        run: |
+         sudo apt-get update && apt-get install guix
+         guix pull
       - name: "Ensure no locale warning"
         run: |
           test -z "$(guix --version 2>&1 >/dev/null)"

--- a/.github/workflows/guix.yml
+++ b/.github/workflows/guix.yml
@@ -1,0 +1,45 @@
+---
+# File : guix.yml
+
+name: Guix/Guile 3.0
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  x86_64-linux-gnu:
+    name: "Guix build on latest commit for x86_64 system"
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Install Guix"
+        uses: "PromyLOPh/guix-install-action@v1"
+      - name: "Ensure no locale warning"
+        run: |
+          test -z "$(guix --version 2>&1 >/dev/null)"
+      - name: "Checkout repository"
+        uses: "actions/checkout@v3"
+      - name: "Build project guile-ssh"
+        run: |
+          guix build --file guix.scm guile-ssh
+  aarch64-linux-gnu:
+    name: "Guix build on latest commit for x86_64 system"
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Install Guix"
+        uses: "PromyLOPh/guix-install-action@v1"
+      - name: "Ensure no locale warning"
+        run: |
+          test -z "$(guix --version 2>&1 >/dev/null)"
+      - name: "Checkout repository"
+        uses: "actions/checkout@v3"
+      - name: "Build project guile-ssh"
+        run: |
+          guix build --file guix.scm guile-ssh
+
+# End of guix.yml
+...

--- a/.github/workflows/guix.yml
+++ b/.github/workflows/guix.yml
@@ -5,15 +5,14 @@ name: Guix/Guile 3.0
 
 on:
   push:
-  #   branches:
-  #     - master
-  # pull_request:
-  #   branches:
-  #     - master
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   x86_64-linux-gnu:
-    name: "Guix build on latest commit for x86_64 system"
     runs-on: "ubuntu-latest"
     steps:
       - name: "Guix cache"
@@ -35,7 +34,6 @@ jobs:
         run: |
           guix build --file=guix.scm guile-ssh
   aarch64-linux-gnu:
-    name: "Guix build on latest commit for aarch64 system"
     runs-on: "ubuntu-latest"
     steps:
       - name: "Guix cache"

--- a/.github/workflows/guix.yml
+++ b/.github/workflows/guix.yml
@@ -25,9 +25,7 @@ jobs:
           restore-keys: |
             guix-cache-
       - name: "Install Guix"
-        run: |
-         sudo apt-get update && sudo apt-get install guix
-         guix pull
+        uses: "PromyLOPh/guix-install-action@v1"
       - name: "Ensure no locale warning"
         run: |
           test -z "$(guix --version 2>&1 >/dev/null)"
@@ -49,9 +47,7 @@ jobs:
           restore-keys: |
             guix-cache-
       - name: "Install Guix"
-        run: |
-         sudo apt-get update && sudo apt-get install guix
-         guix pull
+        uses: "PromyLOPh/guix-install-action@v1"
       - name: "Ensure no locale warning"
         run: |
           test -z "$(guix --version 2>&1 >/dev/null)"
@@ -59,7 +55,7 @@ jobs:
         uses: "actions/checkout@v3"
       - name: "Build project guile-ssh"
         run: |
-          guix build --file=guix.scm guile-ssh
+          guix build --target=aarch64-linux-gnu --file=guix.scm guile-ssh
 
 # End of guix.yml
 ...


### PR DESCRIPTION
This PR adds new GitHub Actions flow to build over the latest Guix commit from mirror hosted on GitHub https://github.com/guix-mirror/guix.

I've tried to use Ubuntu native `guix` package but due to it's age the `guix pull` takes forever (15min+) complete and most of my tests failed.

I've used maintained GitHub action instead https://github.com/PromyLOPh/guix-install-action it takes about 10min but not failes, I guess it depens on the the time when mirror was synced. 