### PR TITLE
Correct wrong bytevector verify branch

### DIFF
--- a/modules/ssh/key.scm
+++ b/modules/ssh/key.scm
@@ -136,7 +136,7 @@ Return the signing key on success, #f on error."
     ((? string?)
      (%gssh-verify (string->utf8 data) signature namespace))
     ((? bytevector?)
-     (%gssh-sign data key namespace hash))
+     (%gssh-verify data signature namespace))
     (_
      (format (current-error-port) "verify: DATA must be a string or bytevector")
      #f)))

--- a/tests/key.scm
+++ b/tests/key.scm
@@ -20,7 +20,8 @@
 
 (add-to-load-path (getenv "abs_top_srcdir"))
 
-(use-modules (srfi srfi-64)
+(use-modules (rnrs bytevectors)
+             (srfi srfi-64)
              (ssh key)
              (ssh version)
              (tests common))
@@ -367,6 +368,33 @@
  (test-skip "verify: RSA, invalid signature"))
 (test-assert-with-log "verify: RSA, invalid signature"
   (not (verify %test-data "invalid-signature")))
+
+(unless-sshsig-supported
+ (test-skip "sign: RSA, bytevector data"))
+(test-assert-with-log "sign: RSA, bytevector data"
+  (let* ((private-key (private-key-from-file %rsakey))
+         (signature (sign (string->utf8 %test-data) private-key)))
+    (and (string? signature)
+         (not (string-null? signature)))))
+
+(unless-sshsig-supported
+ (test-skip "verify: RSA, bytevector data, valid signature"))
+(test-assert-with-log "verify: RSA, bytevector data, valid signature"
+  (let* ((private-key (private-key-from-file %rsakey))
+         (signature (sign (string->utf8 %test-data) private-key)))
+    (verify (string->utf8 %test-data) signature)))
+
+(unless-sshsig-supported
+ (test-skip "verify: RSA, bytevector data, invalid signature"))
+(test-assert-with-log "verify: RSA, bytevector data, invalid signature"
+  (not (verify (string->utf8 %test-data) "invalid-signature")))
+
+(unless-sshsig-supported
+ (test-skip "verify: RSA, string data signed, verified as bytevector"))
+(test-assert-with-log "verify: RSA, string data signed, verified as bytevector"
+  (let* ((private-key (private-key-from-file %rsakey))
+         (signature (sign %test-data private-key)))
+    (verify (string->utf8 %test-data) signature)))
 
 (unless-sshsig-supported
  (test-skip "sign with custom namespace and hash"))


### PR DESCRIPTION
* modules/ssh/key.scm (verify): An unchecked copy-paste made its way in the bytevector branch of the verify function, correct it.

* tests/key.scm ("sign: RSA, bytevector data") ("verify: RSA, bytevector data, valid signature")
("verify: RSA, bytevector data, invalid signature") ("verify: RSA, string data signed, verified as bytevector"): Add regression tests (they fail without the fix).

Disclaimer: tests are generated with the help of gen AI, but I read them and tested them properly.