### PR TITLE
Add support for FISO2/U2F sk- key types

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,12 @@ Copyright (C) Nicolas Graves <ngraves@ngraves.fr>
   are permitted in any medium without royalty provided the copyright
   notice and this notice are preserved.
 
+* Changes since version 1.0.0
+** modules/key-type.c: Add support for FIDO2/U2F "sk-*" key types :FEATURE:
+Add =sk-ecdsa=, =sk-ecdsa-cert01=, =sk-ed25519= and =sk-ed25519-cert01= key
+types, mapping to libssh's =SSH_KEYTYPE_SK_ECDSA=, =SSH_KEYTYPE_SK_ECDSA_CERT01=,
+=SSH_KEYTYPE_SK_ED25519= and =SSH_KEYTYPE_SK_ED25519_CERT01=, for libssh >= 0.10.
+
 * Changes in version 1.0.0 (2026-03-25)
 ** modules/ssh/key.scm: =make-keypair= length is now optional :API_CHANGE:
 =libssh='s =ssh_pki_generate= uses a default size when it's set to 0. Make the

--- a/libguile-ssh/key-type.c
+++ b/libguile-ssh/key-type.c
@@ -47,6 +47,13 @@ static const gssh_symbol_t key_types[] = {
   { "ecdsa-p521-cert01", SSH_KEYTYPE_ECDSA_P521_CERT01 },
 #endif
 
+#if HAVE_LIBSSH_0_10
+  { "sk-ecdsa",          SSH_KEYTYPE_SK_ECDSA          },
+  { "sk-ecdsa-cert01",   SSH_KEYTYPE_SK_ECDSA_CERT01   },
+  { "sk-ed25519",        SSH_KEYTYPE_SK_ED25519        },
+  { "sk-ed25519-cert01", SSH_KEYTYPE_SK_ED25519_CERT01 },
+#endif
+
   { "ed25519", SSH_KEYTYPE_ED25519 },
   { "unknown", SSH_KEYTYPE_UNKNOWN },
   { NULL,      -1                  }
@@ -103,7 +110,8 @@ _print (SCM smob, SCM port, scm_print_state *pstate)
 /*
   Convert SSH key type to/from a Scheme symbol.
   Possible symbols are: 'dss, 'rsa, 'rsa1, 'ecdsa, its variants if
-  libssh >= 0.9, 'ed25519, 'unknown.
+  libssh >= 0.9, 'sk-ecdsa, 'sk-ed25519 and their -cert01 variants if
+  libssh >= 0.10, 'ed25519, 'unknown.
 */
 
 SCM

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -71,6 +71,8 @@ EXTRA_DIST = \
   keys/ecdsakey.pub \
   keys/ed25519key \
   keys/ed25519key.pub \
+  keys/skecdsakey.pub \
+  keys/sked25519key.pub \
   keys/rsakey \
   keys/rsakey.pub \
   keys/encrypted-ecdsa-key \

--- a/tests/common.scm
+++ b/tests/common.scm
@@ -46,6 +46,8 @@
             %dsakey-pub
             %ecdsakey
             %ecdsakey-pub
+            %skecdsakey-pub
+            %sked25519key-pub
             %rsakey-encrypted
             %ed25519key-encrypted
             %ecdsakey-encrypted
@@ -95,6 +97,8 @@
 (define %dsakey-pub     (format #f "~a/tests/keys/dsakey.pub"   %topdir))
 (define %ecdsakey       (format #f "~a/tests/keys/ecdsakey"     %topdir))
 (define %ecdsakey-pub   (format #f "~a/tests/keys/ecdsakey.pub" %topdir))
+(define %skecdsakey-pub   (format #f "~a/tests/keys/skecdsakey.pub"   %topdir))
+(define %sked25519key-pub (format #f "~a/tests/keys/sked25519key.pub" %topdir))
 
 (define %rsakey-encrypted     (format #f "~a/tests/keys/encrypted-rsa-key" %topdir))
 (define %ed25519key-encrypted (format #f "~a/tests/keys/encrypted-ed25519-key" %topdir))

--- a/tests/key.scm
+++ b/tests/key.scm
@@ -48,6 +48,10 @@
   (unless (>= %libssh-minor-version 12)
     expr))
 
+(define-syntax-rule (unless-sk-supported expr)
+  (unless (>= %libssh-minor-version 10)
+    expr))
+
 (test-begin-with-log "key")
 
 (test-assert-with-log "public-key-from-file: RSA"
@@ -65,6 +69,16 @@
  (test-skip "public-key-from-file: ECDSA"))
 (test-assert-with-log "public-key-from-file: ECDSA"
   (public-key-from-file %ecdsakey-pub))
+
+(unless-sk-supported
+ (test-skip "public-key-from-file: SK-ECDSA"))
+(test-assert-with-log "public-key-from-file: SK-ECDSA"
+  (public-key-from-file %skecdsakey-pub))
+
+(unless-sk-supported
+ (test-skip "public-key-from-file: SK-ED25519"))
+(test-assert-with-log "public-key-from-file: SK-ED25519"
+  (public-key-from-file %sked25519key-pub))
 
 (test-assert "private-key-from-file: RSA"
   (private-key-from-file %rsakey))
@@ -179,6 +193,16 @@
         ;; For libssh versions prior to 0.9
         (eq? 'ecdsa (get-key-type key)))))
 
+(unless-sk-supported
+ (test-skip "get-key-type: SK-ECDSA"))
+(test-assert-with-log "get-key-type: SK-ECDSA"
+  (eq? 'sk-ecdsa (get-key-type (public-key-from-file %skecdsakey-pub))))
+
+(unless-sk-supported
+ (test-skip "get-key-type: SK-ED25519"))
+(test-assert-with-log "get-key-type: SK-ED25519"
+  (eq? 'sk-ed25519 (get-key-type (public-key-from-file %sked25519key-pub))))
+
 
 (unless-openssl
  (test-skip "private-key-to-file"))
@@ -201,6 +225,10 @@
   "AAAAB3NzaC1kc3MAAACBAOpnJ64w3Qo3HkCCODTPpLqPUrDLg0bxWdoae2tsXFwhBthIlCV8N0hTzOj1Qrgnx/WiuDk5qXSKOHisyqVBv8sGLOUTBy0Fdz1SobZ9+WGu5+5EiJm78MZcgtHXHu1GPuImANifbSaDJpIGKItq0V5WhpLXyQC7o0Vt70sGQboVAAAAFQDeu+6APBWXtqq2Ch+nODn7VDSIhQAAAIA5iGHYbztSq8KnWj1J/6GTvsPp1JFqZ3hFX5wlGIV4XxBdeEZnCPrhYJumM7SRjYjWMpW5eqFNs5o3d+rJPFFwDo7yW10WC3Bfpo5xRxU35xf/aFAVbm3vi/HRQvv4cFrwTLvPHgNYGYdZiHXCXPoYIh+WoKT9n3MfrBXB4hpAmwAAAIEArkWuRnbjfPVFpXrWGw6kMPVdhOZr1ghdlG5bY31y4UKUlmHvXx5YZ776dSRSMJY2u4lS73+SFgwPdkmpgGma/rZdd9gly9T7SiSr/4qXJyS8Muh203xsAU3ukRocY8lsvllKEGiCJmrUTJWmj0UYEDsbqy2k/1Yz2Q/awygyk9c=")
 (define %ecdsakey-pub-string
   "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHcpje/fp21KjuZFKgmKAAwHeYJ6e3ny4LwEVjZr8hOCVlBvqj7/krVqxbwZI7EcowbpYI1F8ZszS7zfUhKT3U4=")
+(define %skecdsakey-pub-string
+  "AAAAInNrLWVjZHNhLXNoYTItbmlzdHAyNTZAb3BlbnNzaC5jb20AAAAIbmlzdHAyNTYAAABBBG/X90PSo1sFubgmYfBr0BB0fDNg4EOSm0ABQlzItfeRzySgouhAXquFQoZ5k/qm/4BqdVFPI538hMZSZluC3uEAAAAUc3NoOnRlc3RAZXhhbXBsZS5jb20=")
+(define %sked25519key-pub-string
+  "AAAAGnNrLXNzaC1lZDI1NTE5QG9wZW5zc2guY29tAAAAINr1udr8IT2FdkMxfojftF7oCXM1VmHTIHwP9TfxJLa+AAAAFHNzaDp0ZXN0QGV4YW1wbGUuY29t")
 
 
 (test-equal "public-key->string, RSA"
@@ -244,6 +272,18 @@
       (public-key->string (string->public-key %ecdsakey-pub-string 'ecdsa-p256))
       (public-key->string (string->public-key %ecdsakey-pub-string 'ecdsa)))
   %ecdsakey-pub-string)
+
+(unless-sk-supported
+ (test-skip "string->public-key, SK-ECDSA"))
+(test-equal "string->public-key, SK-ECDSA"
+  (public-key->string (string->public-key %skecdsakey-pub-string 'sk-ecdsa))
+  %skecdsakey-pub-string)
+
+(unless-sk-supported
+ (test-skip "string->public-key, SK-ED25519"))
+(test-equal "string->public-key, SK-ED25519"
+  (public-key->string (string->public-key %sked25519key-pub-string 'sk-ed25519))
+  %sked25519key-pub-string)
 
 (test-assert-with-log "string->public-key, RSA, gc test"
   (let ((max-keys 1000))

--- a/tests/keys/skecdsakey.pub
+++ b/tests/keys/skecdsakey.pub
@@ -1,0 +1,1 @@
+sk-ecdsa-sha2-nistp256@openssh.com AAAAInNrLWVjZHNhLXNoYTItbmlzdHAyNTZAb3BlbnNzaC5jb20AAAAIbmlzdHAyNTYAAABBBG/X90PSo1sFubgmYfBr0BB0fDNg4EOSm0ABQlzItfeRzySgouhAXquFQoZ5k/qm/4BqdVFPI538hMZSZluC3uEAAAAUc3NoOnRlc3RAZXhhbXBsZS5jb20= phoenix@phoenix-pc

--- a/tests/keys/sked25519key.pub
+++ b/tests/keys/sked25519key.pub
@@ -1,0 +1,1 @@
+sk-ssh-ed25519@openssh.com AAAAGnNrLXNzaC1lZDI1NTE5QG9wZW5zc2guY29tAAAAINr1udr8IT2FdkMxfojftF7oCXM1VmHTIHwP9TfxJLa+AAAAFHNzaDp0ZXN0QGV4YW1wbGUuY29t phoenix@phoenix-pc


### PR DESCRIPTION
I noticed a few key types were missing, it's probably a good idea to add them.

* libguile-ssh/key-type.c (key_types): Add missing key types sk-ecdsa, sk-ecdsa-cert01, sk-ed25519, sk-ed25519-cert01.
* tests/keys/skecdsakey.pub: Add new test key.
* tests/keys/sked25519key.pub: Likewise.
* tests/Makefile.am (EXTRA_DIST): Record them.
* tests/common.scm (%skecdsakey-pub, %sked25519key-pub): Add them.
* tests/key.scm (unless-sk-supported): Add helper macro. (%skecdsakey-pub-string, %sked25519-pub-string): Add helper variables. ("public-key-from-file: SK-ECDSA", "public-key-from-file: SK-ED25519") ("get-key-type: SK-ECDSA", "get-key-type: SK-ED25519") ("string->public-key, SK-ECDSA", "string->public-key, SK-ED25519"): Add tests.
* NEWS: Add a entry.